### PR TITLE
Add rel=canonical

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,6 +26,7 @@
 		<link href="/css/normalize.css" rel="stylesheet" type="text/css" />
 		<link href="/css/webflow.css" rel="stylesheet" type="text/css" />
 		<link href="/css/main.css" rel="stylesheet" type="text/css" />
+		<link rel="canonical" href="https://wikiforge.net" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 		<script type="application/ld+json">[{"@context":"https:\/\/schema.org","@type":"WebPage","headline":"WikiForge","url":"/","thumbnailUrl":"","dateCreated":"","creator":[],"keywords":[]}]</script>


### PR DESCRIPTION
Google somehow indexed a server IP used by us and might be using it as canonical when you search for WikiForge as it pops up in the results so the goal here is to tell search engines which is canonical